### PR TITLE
Update to latest core and html packages

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,8 @@
         "Pure"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.3 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0"
+        "elm-lang/core": "4.0.3 <= v < 6.0.0",
+        "elm-lang/html": "1.1.0 <= v < 3.0.0"
     },
     "elm-version": "0.17.1 <= v < 0.19.0"
 }


### PR DESCRIPTION
This package won't install with the current 0.18 release, because the core and html versions are incompatible. This should fix that problem.